### PR TITLE
Support for the new URLs structure and new calendar endpoint data format

### DIFF
--- a/octo_client/models.py
+++ b/octo_client/models.py
@@ -91,7 +91,10 @@ class Product(BaseModel):
 
 @dataclass
 class DailyAvailability(BaseModel):
+    productId: str
+    optionId: str
     localDate: date
+    capacity: int
     status: str
 
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open(path.join(here, 'README.md')) as f:
 
 setup(
     name='OCTO-API-client',
-    version='0.1.0',
+    version='0.1.1',
     description='HTTP client for OCTO (Open Connection for Tourism) APIs.',
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -10,19 +10,23 @@ def test_incorrect_supplier_id(client, mocked_responses):
 
 
 def test_incorrect_api_key(client, mocked_responses):
-    mocked_responses.add(responses.GET, 'https://api.my-booking-platform.com/v1/products', status=403)
+    mocked_responses.add(responses.GET, 'https://api.my-booking-platform.com/v1/suppliers/0001/products', status=403)
     with pytest.raises(exceptions.Unauthorized):
         client.get_products(supplier_id='0001')
 
 
 def test_bad_request(client, mocked_responses):
-    mocked_responses.add(responses.GET, 'https://api.my-booking-platform.com/v1/products', status=403)
+    mocked_responses.add(responses.GET, 'https://api.my-booking-platform.com/v1/suppliers/0001/products', status=403)
     with pytest.raises(exceptions.Unauthorized):
         client.get_products(supplier_id='0001')
 
 
 @pytest.mark.parametrize('status_code', (404, 500))
 def test_api_exception(status_code, client, mocked_responses):
-    mocked_responses.add(responses.GET, 'https://api.my-booking-platform.com/v1/products', status=status_code)
+    mocked_responses.add(
+        responses.GET,
+        'https://api.my-booking-platform.com/v1/suppliers/0001/products',
+        status=status_code,
+    )
     with pytest.raises(exceptions.ApiError):
         client.get_products(supplier_id='0001')


### PR DESCRIPTION
Main changes:
- all the supplier-related endpoints now have a `suppliers/{supplier_id}/` prefix.
- calendar endpoint know accepts a list of `product_id` `option_id` pairs and returns availability for each product-option-day.