### PR TITLE
Adding extra fields to the models (Capabilities)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.3
+
+- Adding `extra_fields` to each model to keep additional fields used by different capabilities.

--- a/README.md
+++ b/README.md
@@ -33,3 +33,13 @@ To run all linters and tests:
 If you want to run a specific test
 
     $ pytest -k test_name
+
+
+## Usage
+
+```
+from octo_client import OctoClient
+
+client = OctoClient('https://octo-api.mysupplier.com', 'MY-SECRET_TOKEN')
+client.get_suppliers()
+```

--- a/octo_client/dacite_patch.py
+++ b/octo_client/dacite_patch.py
@@ -1,0 +1,18 @@
+from dataclasses import is_dataclass
+from typing import Any, Type
+
+from dacite import Config
+from dacite.core import _build_value_for_collection, _build_value_for_union
+from dacite.data import Data
+from dacite.types import extract_origin_collection, is_generic_collection, is_instance, is_union
+
+
+def _build_value(type_: Type, data: Any, config: Config) -> Any:
+    if is_union(type_):
+        return _build_value_for_union(union=type_, data=data, config=config)
+    elif is_generic_collection(type_) and is_instance(data, extract_origin_collection(type_)):
+        return _build_value_for_collection(collection=type_, data=data, config=config)
+    elif is_dataclass(type_) and is_instance(data, Data):
+        # modification: using from_dict from model instead of the generic one
+        return type_.from_dict(data)
+    return data

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open(path.join(here, 'README.md')) as f:
 
 setup(
     name='OCTo-API-client',
-    version='0.1.2',
+    version='0.1.3',
     description='HTTP client for OCTo (Open Connection for Tourism) APIs.',
     long_description=long_description,
     long_description_content_type='text/markdown',
@@ -32,7 +32,7 @@ setup(
         'tests': [
             'flake8-isort==2.7.0',
             'flake8==3.7.9',
-            'mypy==0.750',
+            'mypy==0.770',
             'pytest-cov==2.8.1',
             'pytest==5.3.1',
             'responses==0.10.7',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,8 +21,10 @@ def client(mocked_responses):
                 'website': 'https://acme-tours.co.fake',
                 'email': 'info@acme-tours.co.fake',
                 'telephone': '+1 888-555-1212',
-                'address': '123 Main St, Anytown USA'
-            }
+                'address': '123 Main St, Anytown USA',
+                'country': 'US',
+            },
+            'timezone': 'EST',
         }
     ])
     return OctoClient('http://fake-api.local', 'bar')

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -67,54 +67,61 @@ BOOKING_JSON = {
         }
     ],
 }
-BOOKING_MODEL = m.Booking(
-    uuid='f149068e-300e-452a-a856-3f091239f1d7',
-    status='ON_HOLD',
-    utcHoldExpiration=datetime(2019, 10, 31, 8, 30, tzinfo=timezone.utc),
-    utcConfirmedAt=datetime(2019, 10, 31, 8, 30, tzinfo=timezone.utc),
-    productId='adult',
-    optionId='LR1-01',
-    availability=m.Availability(
-        id='28271273-a317-40fc-8f42-79725a7072a3',
-        localDateTimeStart=datetime(2019, 10, 31, 8, 30, tzinfo=timezone.utc),
-        localDateTimeEnd=datetime(2019, 10, 31, 10, 0, tzinfo=timezone.utc),
-    ),
-    contact=m.Contact(
-        fullName='Mr. Traveller',
-        emailAddress='traveller@fake.com',
-        phoneNumber='+1 555-555-1212',
-        locales=['en-GB', 'en-US', 'en'],
-        country='GB'
-    ),
-    deliveryMethods=['VOUCHER'],
-    voucher=m.Ticket(
-        deliveryOptions=[
-            m.DeliveryOption(deliveryFormat='CODE39', deliveryValue='01234567890')
+BOOKING_MODEL = m.Booking.from_dict({
+    'uuid': 'f149068e-300e-452a-a856-3f091239f1d7',
+    'status': 'ON_HOLD',
+    'utcHoldExpiration': datetime(2019, 10, 31, 8, 30, tzinfo=timezone.utc).isoformat(),
+    'utcConfirmedAt': datetime(2019, 10, 31, 8, 30, tzinfo=timezone.utc).isoformat(),
+    'utcDeliveredAt': datetime(2019, 10, 31, 8, 30, tzinfo=timezone.utc).isoformat(),
+    'productId': 'adult',
+    'optionId': 'LR1-01',
+    'availability': {
+        'id': '28271273-a317-40fc-8f42-79725a7072a3',
+        'localDateTimeStart': datetime(2019, 10, 31, 8, 30, tzinfo=timezone.utc).isoformat(),
+        'localDateTimeEnd': datetime(2019, 10, 31, 10, 0, tzinfo=timezone.utc).isoformat(),
+    },
+    'contact': {
+        'fullName': 'Mr. Traveller',
+        'emailAddress': 'traveller@fake.com',
+        'phoneNumber': '+1 555-555-1212',
+        'locales': ['en-GB', 'en-US', 'en'],
+        'country': 'GB'
+    },
+    'deliveryMethods': ['VOUCHER'],
+    'voucher': {
+        'deliveryOptions': [
+            {
+                'deliveryFormat': 'CODE39',
+                'deliveryValue': '01234567890',
+            }
         ],
-        redemptionMethod='DIGITAL',
-        utcDeliveredAt=datetime(2019, 10, 31, 8, 30, tzinfo=timezone.utc),
-        utcRedeemedAt=datetime(2019, 10, 31, 8, 30, tzinfo=timezone.utc),
-    ),
-    unitItems=[
-        m.UnitItemTicket(
-            uuid='6be0409f-181e-4520-acc1-cc6791896859',
-            unitId='adult',
-            ticket=m.BookingTicket(
-                deliveryOptions=[
-                    m.DeliveryOption(deliveryFormat='CODE39', deliveryValue='01234567890')
+        'redemptionMethod': 'DIGITAL',
+        'utcDeliveredAt': datetime(2019, 10, 31, 8, 30, tzinfo=timezone.utc).isoformat(),
+        'utcRedeemedAt': datetime(2019, 10, 31, 8, 30, tzinfo=timezone.utc).isoformat(),
+    },
+    'unitItems': [
+        {
+            'uuid': '6be0409f-181e-4520-acc1-cc6791896859',
+            'unitId': 'adult',
+            'ticket': {
+                'deliveryOptions': [
+                    {
+                        'deliveryFormat': 'CODE39',
+                        'deliveryValue': '01234567890',
+                    }
                 ],
-                redemptionMethod='DIGITAL',
-                utcDeliveredAt=datetime(2019, 10, 31, 8, 30, tzinfo=timezone.utc),
-                utcRedeemedAt=datetime(2019, 10, 31, 8, 30, tzinfo=timezone.utc),
-            ),
-            resellerReference='001-002',
-            supplierReference='ABC-123'
-        )
+                'redemptionMethod': 'DIGITAL',
+                'utcDeliveredAt': datetime(2019, 10, 31, 8, 30, tzinfo=timezone.utc).isoformat(),
+                'utcRedeemedAt': datetime(2019, 10, 31, 8, 30, tzinfo=timezone.utc).isoformat(),
+            },
+            'resellerReference': '001-002',
+            'supplierReference': 'ABC-123'
+        }
     ],
-    resellerReference='001-002',
-    supplierReference='ABC-123',
-    refreshFrequency='HOURLY',
-)
+    'resellerReference': '001-002',
+    'supplierReference': 'ABC-123',
+    'refreshFrequency': 'HOURLY',
+})
 
 
 def test_suppliers_list(client: OctoClient, mocked_responses):
@@ -129,8 +136,14 @@ def test_suppliers_list(client: OctoClient, mocked_responses):
                 email='info@acme-tours.co.fake',
                 telephone='+1 888-555-1212',
                 description=None,
-                website='https://acme-tours.co.fake'
-            )
+                website='https://acme-tours.co.fake',
+                extra_fields={
+                    'country': 'US',
+                },
+            ),
+            extra_fields={
+                'timezone': 'EST',
+            },
         )
     ]
     assert client.supplier_url_map == {
@@ -161,24 +174,12 @@ def test_products(client: OctoClient, mocked_responses):
                     'id': '345314bb-aaaf-4ba2-b3ef-ff15ea39a0ae',
                     'internalName': 'Studio Tour',
                     'reference': None,
-                    'restrictions': {
-                        'minUnits': 0,
-                        'maxUnits': None
-                    },
                     'units': [
                         {
                             'id': 'adult',
                             'internalName': 'Studio Tour',
                             'reference': None,
                             'type': 'ADULT',
-                            'restrictions': {
-                                'minAge': None,
-                                'maxAge': None,
-                                'idRequired': False,
-                                'minQuantity': 7,
-                                'maxQuantity': None,
-                                'accompaniedBy': []
-                            }
                         }
                     ]
                 }
@@ -201,24 +202,12 @@ def test_products(client: OctoClient, mocked_responses):
                     'id': 'DEFAULT',
                     'internalName': 'DEFAULT',
                     'reference': None,
-                    'restrictions': {
-                        'minUnits': 0,
-                        'maxUnits': None
-                    },
                     'units': [
                         {
                             'id': 'adult',
                             'internalName': 'VIP Tour',
                             'reference': None,
                             'type': 'ADULT',
-                            'restrictions': {
-                                'minAge': None,
-                                'maxAge': None,
-                                'idRequired': False,
-                                'minQuantity': 7,
-                                'maxQuantity': None,
-                                'accompaniedBy': []
-                            }
                         }
                     ]
                 }
@@ -249,12 +238,15 @@ def test_products(client: OctoClient, mocked_responses):
                             id='adult',
                             internalName='Studio Tour',
                             type='ADULT',
-                            reference=None
+                            reference=None,
+                            extra_fields={},
                         )
                     ],
-                    reference=None
+                    reference=None,
+                    extra_fields={},
                 )
-            ]
+            ],
+            extra_fields={},
         ),
         m.Product(
             id='3e803053-6f39-46f7-8a67-2114de59b135',
@@ -278,12 +270,15 @@ def test_products(client: OctoClient, mocked_responses):
                             id='adult',
                             internalName='VIP Tour',
                             type='ADULT',
-                            reference=None
+                            reference=None,
+                            extra_fields={},
                         )
                     ],
-                    reference=None
+                    reference=None,
+                    extra_fields={},
                 )
-            ]
+            ],
+            extra_fields={},
         ),
     ]
     assert len(mocked_responses.calls) == 2, 'Too many requests'
@@ -331,21 +326,25 @@ def test_calendar(client: OctoClient, mocked_responses):
             localDate=date(2020, 6, 1),
             status='AVAILABLE',
             vacancies=14,
+            extra_fields={},
         ),
         m.AvailabilityCalendarItem(
             localDate=date(2020, 6, 1),
             status='AVAILABLE',
             vacancies=18,
+            extra_fields={},
         ),
         m.AvailabilityCalendarItem(
             localDate=date(2020, 6, 2),
             status='AVAILABLE',
             vacancies=28,
+            extra_fields={},
         ),
         m.AvailabilityCalendarItem(
             localDate=date(2020, 6, 2),
             status='AVAILABLE',
             vacancies=31,
+            extra_fields={},
         ),
     ]
     assert len(mocked_responses.calls) == 2, 'Too many requests'
@@ -396,6 +395,7 @@ def test_availability(client: OctoClient, mocked_responses):
             localDateTimeEnd=datetime(2020, 12, 1, 11, 0, tzinfo=timezone(timedelta(days=-1, seconds=57600))),
             status='AVAILABLE',
             vacancies=14,
+            extra_fields={},
         ),
         m.AvailabilityItem(
             id='2020-12-01T09:30:00-08:00',
@@ -403,6 +403,7 @@ def test_availability(client: OctoClient, mocked_responses):
             localDateTimeEnd=datetime(2020, 12, 1, 11, 30, tzinfo=timezone(timedelta(days=-1, seconds=57600))),
             status='AVAILABLE',
             vacancies=13,
+            extra_fields={},
         ),
         m.AvailabilityItem(
             id='2020-12-01T10:00:00-08:00',
@@ -410,6 +411,7 @@ def test_availability(client: OctoClient, mocked_responses):
             localDateTimeEnd=datetime(2020, 12, 1, 12, 0, tzinfo=timezone(timedelta(days=-1, seconds=57600))),
             status='AVAILABLE',
             vacancies=12,
+            extra_fields={},
         ),
     ]
     assert len(mocked_responses.calls) == 2, 'Too many requests'
@@ -437,7 +439,7 @@ def test_test_availability(client: OctoClient, mocked_responses):
         product_id='bar',
         option_id='baz',
         availability_ids=['2020-12-01T15:30:00-08:00'],
-        units=[m.UnitQuantity(unitId='adult', quantity=2)],
+        units=[m.UnitQuantity(unitId='adult', quantity=2, extra_fields={})],
     )
     assert availability == [
         m.AvailabilityItem(
@@ -446,6 +448,7 @@ def test_test_availability(client: OctoClient, mocked_responses):
             localDateTimeEnd=datetime(2020, 12, 1, 17, 30, tzinfo=timezone(timedelta(days=-1, seconds=57600))),
             status='AVAILABLE',
             vacancies=14,
+            extra_fields={},
         )
     ]
     assert len(mocked_responses.calls) == 2, 'Too many requests'
@@ -479,8 +482,10 @@ def test_create_booking(client: OctoClient, mocked_responses):
                 m.UnitItem(
                     uuid='6be0409f-181e-4520-acc1-cc6791896859',
                     unitId='adult',
+                    extra_fields={},
                 )
             ],
+            extra_fields={},
         ),
     )
     assert booking == BOOKING_MODEL
@@ -495,10 +500,11 @@ def test_create_booking(client: OctoClient, mocked_responses):
         'unitItems': [{
             'uuid': '6be0409f-181e-4520-acc1-cc6791896859',
             'unitId': 'adult',
-            'resellerReference': None
+            'resellerReference': None,
+            'extra_fields': {},
         }],
         'holdExpirationMinutes': None,
-        'resellerReference': None
+        'resellerReference': None,
     }
 
 
@@ -519,7 +525,9 @@ def test_booking_confirmation(client: OctoClient, mocked_responses):
                 phoneNumber='+1 555-555-1212',
                 locales=['en-GB', 'en-US', 'en'],
                 country='GB',
-            )
+                extra_fields={},
+            ),
+            extra_fields={},
         )
     )
     assert booking == BOOKING_MODEL
@@ -534,7 +542,8 @@ def test_booking_confirmation(client: OctoClient, mocked_responses):
             'emailAddress': 'traveller@fake.local',
             'phoneNumber': '+1 555-555-1212',
             'locales': ['en-GB', 'en-US', 'en'],
-            'country': 'GB'
+            'country': 'GB',
+            'extra_fields': {},
         },
         'resellerReference': '001-002'
     }


### PR DESCRIPTION
New OCTo capabilities might extend data models in requests and responses. To keep the generic approach I'm adding a `extra_fields` dictionary to each model to keep there all the extra fields that were added by the capabilities in the response objects.

Example:
```
@dataclass
class SomeModel(BaseModel):
    a: str
    b: str
```
response from the supplier:
```
{
    "a": "foo",
    "b": "bar",
    "c": "baz",  # extra field added by some capability
}
```
model build from that response:
```
SomeModel.from_dict(response)
SomeModel(a="foo", b="bar", extra_fields={"c": "baz"})
```

It also can work in the opposite way if the supplier supports some extra data in the request object:
```
model = SomeModel(a="foo", b="bar", extra_fields={"c": "baz"})
model.as_dict()
{"a": "foo", "b": "bar", "c": "baz"}
```

#### Dacite workaround:

When creating a nested dataclass via dacite we might do that only by using `from_dict` method from the dacite lib. We cannot override this method for each object. That is why I created a small patch that allows us to use a `from_dict` method available for every dataclass for creating an instance.