### PR TITLE
Hide user data in logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.1.5
+
+- Hide sensitive data in logs
+
 ## 1.1.4
 
 - add flag to log requests

--- a/octo_client/client.py
+++ b/octo_client/client.py
@@ -1,3 +1,4 @@
+import copy
 import logging
 from datetime import date
 from typing import Any, Callable, Dict, List, Optional, Union
@@ -148,10 +149,10 @@ class OctoClient(object):
         return response_json
 
     def _filter_request_log_data(
-        self, data_length: int, content: Union[str, dict]
+        self, data_length: int, request_content: Union[str, dict]
     ) -> Optional[Union[str, dict]]:
         if self.log_requests:
-            content = hide_sensitive_data(content)
+            content = hide_sensitive_data(copy.deepcopy(request_content))
             if self.log_size_limit and data_length > self.log_size_limit:
                 return "TRUNCATED"
             return content
@@ -161,10 +162,10 @@ class OctoClient(object):
         self, response_length: int, response_content: Union[str, dict]
     ) -> Optional[Union[str, dict]]:
         if self.log_responses:
-            response_content = hide_sensitive_data(response_content)
+            content = hide_sensitive_data(copy.deepcopy(response_content))
             if self.log_size_limit and response_length > self.log_size_limit:
                 return "TRUNCATED"
-            return response_content
+            return content
         return None
 
     def _get_headers(self) -> Dict[str, str]:
@@ -531,7 +532,3 @@ class OctoClient(object):
 
         response = self._http_patch(f"bookings/{uuid}", supplier_id=supplier_id, json=payload)
         return models.Booking.from_dict(response)
-
-
-def test_hide_sensitive_data():
-    pass

--- a/octo_client/const.py
+++ b/octo_client/const.py
@@ -1,8 +1,24 @@
 from enum import Enum
 
+PRIVATE_DATA_REPLACEMENT = "[Filtered private data]"
+PRIVATE_DATA_KEYS = [
+    "name",
+    "email",
+    "phone",
+    "mobile",
+    "phone",
+    "address",
+    "street",
+    "city",
+    "zip",
+    "country",
+    "state",
+]
+
 
 class EnumWithMissing(Enum):
     """An Enum class that overrides the `_missing_()` method to return the class' OTHER member."""
+
     @classmethod
     def _missing_(cls, value):
         for member in cls:

--- a/octo_client/utils.py
+++ b/octo_client/utils.py
@@ -1,0 +1,24 @@
+from typing import List, Union
+
+from octo_client.const import PRIVATE_DATA_KEYS, PRIVATE_DATA_REPLACEMENT
+
+
+def hide_sensitive_data(
+    data: Union[str, dict], keys: List[str] = PRIVATE_DATA_KEYS
+) -> Union[str, dict]:
+    """
+    Hide sensitive data from a nested dict by doing a partial match on the keys.
+    data: dict to be filtered
+    keys: list of keys to be filtered
+    """
+    if isinstance(data, str):
+        return data
+
+    for k, v in data.items():
+        if isinstance(v, dict):
+            hide_sensitive_data(v, keys)
+
+        for key in keys:
+            if key in k.lower():
+                data[k] = PRIVATE_DATA_REPLACEMENT
+    return data

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "octo-api-client"
-version = "1.1.4"
+version = "1.1.5"
 description = "HTTP client for OCTo (Open Connection for Tourism) APIs."
 authors = ["Tiqets <connections@tiqets.com>"]
 license = "MIT"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,41 @@
+from octo_client.utils import hide_sensitive_data
+
+
+def test_hide_sensitive_data():
+    data = {
+        "nonSensitiveData": "foo",
+        "otherNonSensitiveData": {
+            "isItSensitive": "I don't think so ;)",
+        },
+        "userAddress": "1234 Main St",
+        "userCity": "Anytown",
+        "userZip": "12345",
+        "userCountry": "USA",
+        "userState": "CA",
+        "contact": {
+            "firstName": "John",
+            "lastName": "Doe",
+            "userEmail": "foo@boo.com",
+            "userPhone": "1234567890",
+        },
+    }
+
+    result = hide_sensitive_data(data)
+
+    assert result == {
+        "nonSensitiveData": "foo",
+        "otherNonSensitiveData": {
+            "isItSensitive": "I don't think so ;)",
+        },
+        "userAddress": "[Filtered private data]",
+        "userCity": "[Filtered private data]",
+        "userZip": "[Filtered private data]",
+        "userCountry": "[Filtered private data]",
+        "userState": "[Filtered private data]",
+        "contact": {
+            "firstName": "[Filtered private data]",
+            "lastName": "[Filtered private data]",
+            "userEmail": "[Filtered private data]",
+            "userPhone": "[Filtered private data]",
+        },
+    }


### PR DESCRIPTION
**Why:** 
We're currently displaying user-sensitive data in the logs and that's something we do not want 💩

**How:**
Add a function to search and replace user-sensitive data using partial matching. meaning, any key in the response payload that mentions for example `email` or `name` will be automatically hidden.